### PR TITLE
Allow livewire to update all datasets

### DIFF
--- a/src/resources/views/chart-template-livewire.blade.php
+++ b/src/resources/views/chart-template-livewire.blade.php
@@ -98,10 +98,16 @@
 
                 chart.data.labels = labels
 
+                const datasetsLength = chart.data.datasets.length;
+
                 if (chart.config.type === 'treemap') {
-                    chart.data.datasets[0].tree = datasets[0].tree
+                  for (let i = 0; i < datasetsLength; i++) {
+                    chart.data.datasets[i].tree = datasets[i].tree
+                  }
                 } else {
-                    chart.data.datasets[0].data = datasets[0].data
+                  for (let i = 0; i < datasetsLength; i++) {
+                    chart.data.datasets[i].data = datasets[i].data
+                  }
                 }
 
                 chart.update()


### PR DESCRIPTION
Right now, Livewire will only update the first dataset. This allows to update all datasets.

